### PR TITLE
Android and GL4ES optimizations

### DIFF
--- a/app/src/main/java/ui/activity/GameActivity.kt
+++ b/app/src/main/java/ui/activity/GameActivity.kt
@@ -88,6 +88,7 @@ class GameActivity : SDLActivity() {
             try {
                 Os.setenv("OPENMW_GLES_VERSION", "2", true)
                 Os.setenv("LIBGL_ES", "2", true)
+                Os.setenv("OSG_VERTEX_BUFFER_HINT", "VBO", true)
             } catch (e: ErrnoException) {
                 Log.e("OpenMW", "Failed setting environment variables.")
                 e.printStackTrace()

--- a/buildscripts/CMakeLists.txt
+++ b/buildscripts/CMakeLists.txt
@@ -580,7 +580,7 @@ set(OPENMW_PATCH
 	patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/openmw/0009-windowmanagerimp-always-show-mouse-when-possible-pat.patch &&
 	patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/openmw/0010-android-fix-context-being-lost-on-app-minimize.patch &&
 	patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/openmw/0014-settingswindow-save-user-settings-file-when-ok-is-pr.patch &&
-	patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/openmw/0012-components-misc-stringops-use-boost-format-instead-o.patch &&
+#	patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/openmw/0012-components-misc-stringops-use-boost-format-instead-o.patch &&
 	patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/openmw/fix-build.patch &&
 	patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/openmw/refraction-fix.patch &&
 	cp ${CMAKE_SOURCE_DIR}/patches/openmw/android_main.cpp <SOURCE_DIR>/apps/openmw/android_main.cpp

--- a/buildscripts/CMakeLists.txt
+++ b/buildscripts/CMakeLists.txt
@@ -37,8 +37,8 @@ set(MYGUI_VERSION 3.4.1)
 #set(MYGUI_HASH SHA256=d1d5f294670ae71f7200ed4b30859018281d8cfd45d6a38d18b97a4aba604c42)
 
 # https://github.com/ptitSeb/gl4es/releases
-set(GL4ES_VERSION v1.1.4)
-set(GL4ES_HASH SHA256=b565e717c7d192e936bda25f3cb90ad8db398af56414ec08294b6716574c1a6d)
+set(GL4ES_VERSION baf1c7482ee8dd138324a1f670fc04706723ed83)
+#set(GL4ES_HASH SHA256=b565e717c7d192e936bda25f3cb90ad8db398af56414ec08294b6716574c1a6d)
 
 # https://github.com/openscenegraph/OpenSceneGraph/releases
 set(OSG_VERSION 01cc2b585c8456a4ff843066b7e1a8715558289f)
@@ -323,9 +323,10 @@ ExternalProject_Add(gl4es
 	URL_HASH ${GL4ES_HASH}
 	DOWNLOAD_DIR ${download_dir}
 
-	PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/gl4es/shared-library.patch
-	COMMAND patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/gl4es/gamma.patch
-	COMMAND patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/gl4es/keyword-usage.patch
+	PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/gl4es/all_in_one.patch
+#	PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/gl4es/shared-library.patch
+#	COMMAND patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/gl4es/gamma.patch
+#	COMMAND patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/gl4es/keyword-usage.patch
 
 	CONFIGURE_COMMAND ""
 
@@ -334,6 +335,7 @@ ExternalProject_Add(gl4es
 
 	INSTALL_COMMAND mkdir -p ${prefix}/lib/
 	COMMAND cp libs/${app_abi}/libGL.so ${prefix}/lib/
+	COMMAND cp -r <SOURCE_DIR>/include ${prefix}/include/gl4es/
 	COMMAND cp -r <SOURCE_DIR>/include ${prefix}/
 )
 
@@ -354,6 +356,9 @@ ExternalProject_Add(mygui
 	-DMYGUI_BUILD_TOOLS=OFF
 	-DMYGUI_BUILD_PLUGINS=OFF
 	-DFREETYPE_FT2BUILD_INCLUDE_DIR=${prefix}/include/freetype2/
+	-DOPENGL_opengl_LIBRARY=${prefix}/lib/libGL.so
+	-DOPENGL_glx_LIBRARY=${prefix}/lib/libGL.so
+	-DOPENGL_INCLUDE_DIR=${prefix}/include/gl4es/
         -DMYGUI_DONT_USE_OBSOLETE=OFF
 	-DMYGUI_STATIC=ON
 
@@ -480,7 +485,7 @@ ExternalProject_Add(libcollada
 )
 
 set(OSG_COMMON
-	-DOPENGL_PROFILE="GL1"
+	-DOPENGL_PROFILE="GL2"
 	-DDYNAMIC_OPENTHREADS=OFF
 	-DDYNAMIC_OPENSCENEGRAPH=OFF
 	-DBUILD_OSG_PLUGIN_OSG=ON
@@ -494,9 +499,12 @@ set(OSG_COMMON
 	-DJPEG_INCLUDE_DIR=${prefix}/include/
 	-DPNG_INCLUDE_DIR=${prefix}/include/
 	-DFREETYPE_DIR=${prefix}
+	-DOPENGL_opengl_LIBRARY=${prefix}/lib/libGL.so
+	-DOPENGL_glx_LIBRARY=${prefix}/lib/libGL.so
+	-DOPENGL_INCLUDE_DIR=${prefix}/include/gl4es/
 	-DOSG_CPP_EXCEPTIONS_AVAILABLE=TRUE
 	-DOSG_GL1_AVAILABLE=ON
-	-DOSG_GL2_AVAILABLE=OFF
+	-DOSG_GL2_AVAILABLE=ON
 	-DOSG_GL3_AVAILABLE=OFF
 	-DOSG_GLES1_AVAILABLE=OFF
 	-DOSG_GLES2_AVAILABLE=OFF
@@ -555,6 +563,10 @@ set(OPENMW_COMMON
 	-DBUILD_OPENCS=0
 	-DBUILD_WIZARD=0
 	-DBUILD_MYGUI_PLUGIN=0
+	-DOPENGL_opengl_LIBRARY=${prefix}/lib/libGL.so
+	-DOPENGL_glx_LIBRARY=${prefix}/lib/libGL.so
+	-DOPENGL_INCLUDE_DIR=${prefix}/include/gl4es/
+	-DOPENMW_GL4ES_MANUAL_INIT=ON
 	-DOPENAL_INCLUDE_DIR=${prefix}/include/AL/
 	-DBullet_INCLUDE_DIR=${prefix}/include/bullet/
 	-DOPENGL_ES=OFF
@@ -566,9 +578,9 @@ set(OPENMW_PATCH
 	patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/openmw/gamma.patch &&
 	patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/openmw/0001-loadingscreen-disable-for-now.patch &&
 	patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/openmw/0009-windowmanagerimp-always-show-mouse-when-possible-pat.patch &&
-    patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/openmw/0010-android-fix-context-being-lost-on-app-minimize.patch &&
+	patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/openmw/0010-android-fix-context-being-lost-on-app-minimize.patch &&
 	patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/openmw/0014-settingswindow-save-user-settings-file-when-ok-is-pr.patch &&
-#	patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/openmw/0012-components-misc-stringops-use-boost-format-instead-o.patch &&
+	patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/openmw/0012-components-misc-stringops-use-boost-format-instead-o.patch &&
 	patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/openmw/fix-build.patch &&
 	patch -d <SOURCE_DIR> -p1 -t -N < ${CMAKE_SOURCE_DIR}/patches/openmw/refraction-fix.patch &&
 	cp ${CMAKE_SOURCE_DIR}/patches/openmw/android_main.cpp <SOURCE_DIR>/apps/openmw/android_main.cpp

--- a/buildscripts/patches/gl4es/all_in_one.patch
+++ b/buildscripts/patches/gl4es/all_in_one.patch
@@ -1,0 +1,90 @@
+diff --git a/Android.mk b/Android.mk
+index 2290e5ac..8e30ed05 100644
+--- a/Android.mk
++++ b/Android.mk
+@@ -92,13 +92,17 @@ LOCAL_SRC_FILES := \
+ LOCAL_CFLAGS += -g -std=gnu99 -funwind-tables -O3 -fvisibility=hidden -include include/android_debug.h
+ LOCAL_CFLAGS += -DNOX11
+ LOCAL_CFLAGS += -DNO_GBM
+-#LOCAL_CFLAGS += -DNO_INIT_CONSTRUCTOR
++LOCAL_CFLAGS += -DNO_INIT_CONSTRUCTOR
++LOCAL_CFLAGS += -DNOEGL
++LOCAL_CFLAGS += -DNO_LOADER
++LOCAL_CFLAGS += -include include/gl4esinit.h
+ LOCAL_CFLAGS += -DDEFAULT_ES=2
+ //TODO: maybe temporary?
+ LOCAL_CFLAGS += -Wno-typedef-redefinition -Wno-dangling-else
++LOCAL_CFLAGS += -Dasm=__asm__ -Dvolatile=__volatile__
+ 
+ LOCAL_LDLIBS := -llog
+-#building as a static lib
++#building as a shared lib
+ 
+-LOCAL_CFLAGS += -DSTATICLIB
+-include $(BUILD_STATIC_LIBRARY)
++#LOCAL_CFLAGS += -DSTATICLIB
++include $(BUILD_SHARED_LIBRARY)
+diff --git a/src/gl/fpe.h b/src/gl/fpe.h
+index 723f9328..268ce28a 100644
+--- a/src/gl/fpe.h
++++ b/src/gl/fpe.h
+@@ -188,6 +188,7 @@ typedef struct fpe_state_s {
+     unsigned int fragment_prg_enable:1;  // if fragment program is enabled
+     uint16_t     vertex_prg_id;          // Id of vertex program currently binded (0 most of the time), 16bits is more than enough...
+     uint16_t     fragment_prg_id;        // Id of fragment program currently binded (0 most of the time)
++    int16_t gamma;
+ } fpe_state_t;
+ #pragma pack()
+ 
+diff --git a/src/gl/fpe_shader.c b/src/gl/fpe_shader.c
+index 1f57dc8c..15444eae 100644
+--- a/src/gl/fpe_shader.c
++++ b/src/gl/fpe_shader.c
+@@ -1380,6 +1380,11 @@ const char* const* fpe_FragmentShader(shaderconv_need_t* need, fpe_state_t *stat
+         #endif
+     }
+ 
++    if (state->gamma) {
++        sprintf(buff, "fColor.rgb = pow(fColor.rgb, vec3(1.0 / %.3f));\n", state->gamma / 100.0);
++        ShadAppend(buff);
++    }
++
+     //done
+     ShadAppend("gl_FragColor = fColor;\n");
+     ShadAppend("}");
+diff --git a/src/gl/light.c b/src/gl/light.c
+index 00527649..5f8ac7d5 100644
+--- a/src/gl/light.c
++++ b/src/gl/light.c
+@@ -77,6 +77,10 @@ void APIENTRY_GL4ES gl4es_glLightModelfv(GLenum pname, const GLfloat* params) {
+             return;
+         } else gl4es_flush();
+     switch (pname) {
++        case 0x4242:
++            if (glstate->fpe_state)
++                glstate->fpe_state->gamma = params[0] * 100;
++            return;
+         case GL_LIGHT_MODEL_AMBIENT:
+             if(memcmp(glstate->light.ambient, params, 4*sizeof(GLfloat))==0) {
+                 noerrorShim();
+diff --git a/src/gl/shader_hacks.c b/src/gl/shader_hacks.c
+index 35b39497..55d235ce 100644
+--- a/src/gl/shader_hacks.c
++++ b/src/gl/shader_hacks.c
+@@ -540,6 +540,7 @@ static char* ShaderHacks_2(char* shader, char* Tmp, int* tmpsize)
+ 
+ char* ShaderHacks(char* shader)
+ {
++/*
+     char* Tmp = shader;
+     int tmpsize = strlen(Tmp)+10;
+     // specific hacks
+@@ -558,4 +559,6 @@ char* ShaderHacks(char* shader)
+         }
+     }
+     return Tmp;
+-}
+\ No newline at end of file
++*/
++    return shader;
++}


### PR DESCRIPTION
- Update to latest gl4es nightly and use the gl4es initialization and optimization feature by Glebm.
- Merges all gl4es patches into one, also add a patch that fixes the F3 profiler text becoming black after a while in interiors and always being black in exterior, the patch/fix is found out by Sisah.
- Force VBOs both for performance gains and to fix a gl4es nightly texture flicker.
- Use OSG GL2 profile by default, it should have been like that from the start.

Later on we might need to remove the glesv1 option as it's unusable and crashy, OpenMW requires more features where glesv1 lacks.